### PR TITLE
Fix workflow descriptions in the README (github.ref and indents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
         output: sarif-results
 
     - name: Dismiss alerts
-      if: github.ref == 'main'
+      if: github.ref == 'refs/heads/main'
       uses: advanced-security/dismiss-alerts@v1
       with:
         # specify a 'sarif-id' and 'sarif-file'
@@ -105,7 +105,7 @@ jobs:
         wait-for-processing: true
 
     - name: Dismiss alerts
-      if: github.ref == 'main'    
+      if: github.ref == 'refs/heads/main'
       uses: advanced-security/dismiss-alerts@v1
       with:
         # specify a 'sarif-id' and 'sarif-file'

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ CodeQL populates the `suppression` property in its SARIF output based on the res
 name: "CodeQL"
 
 on:
- push:
-   branches: [ main ]
- pull_request:
+  push:
+    branches: [ main ]
+  pull_request:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Hi 👋 . This PR intends to update the following 2 items in the workflow example in the README, which I noticed during my local testing. Thanks in advance for checking 🙇 .

- Indent
  - There's a minor indent mismatch in the `on` section of the workflow.
- github.ref
  - I think the `github.ref` becomes `refs/heads/main` rather than `main` for the main branch.
  - [GitHub Docs - Determining when to use contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#determining-when-to-use-contexts) uses example `if: ${{ github.ref == 'refs/heads/main' }}`.